### PR TITLE
Fix watchtower installation

### DIFF
--- a/functions/watchtower.sh
+++ b/functions/watchtower.sh
@@ -6,5 +6,5 @@
 # GNU:        General Public License v3.0
 ################################################################################
 watchtower () {
-  bash /pg/apps/apps/watchtower/start.sh
+  bash /pg/apps/programs/watchtower/start.sh
 }


### PR DESCRIPTION
The watchtower function was pointing to an invalid path leading to the installation to fail.

Fixes #1